### PR TITLE
Fix blank page when Firebase config missing

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -12,8 +12,17 @@ function App() {
   const [user, setUser] = useState(null);
 
   useEffect(() => {
+    if (!auth) return;
     return onAuthStateChanged(auth, (u) => setUser(u));
   }, []);
+
+  if (!auth) {
+    return (
+      <Box p={2} textAlign="center">
+        Липсва конфигурация за Firebase. Проверете environment променливите.
+      </Box>
+    );
+  }
 
   return (
     <>

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,7 +1,15 @@
 import { render, screen } from '@testing-library/react';
-import App from './App';
 
 test('renders login screen by default', () => {
+  process.env.REACT_APP_FIREBASE_API_KEY = 'test';
+  process.env.REACT_APP_FIREBASE_AUTH_DOMAIN = 'test';
+  process.env.REACT_APP_FIREBASE_DATABASE_URL = 'test';
+  process.env.REACT_APP_FIREBASE_PROJECT_ID = 'test';
+  process.env.REACT_APP_FIREBASE_STORAGE_BUCKET = 'test';
+  process.env.REACT_APP_FIREBASE_MESSAGING_SENDER_ID = 'test';
+  process.env.REACT_APP_FIREBASE_APP_ID = 'test';
+
+  const App = require('./App').default;
   render(<App />);
   expect(screen.getByText(/Вход с Google/i)).toBeInTheDocument();
 });

--- a/src/firebase.js
+++ b/src/firebase.js
@@ -11,21 +11,27 @@ const requiredEnv = [
   'REACT_APP_FIREBASE_APP_ID',
 ];
 
-requiredEnv.forEach((name) => {
-  if (!process.env[name]) {
-    console.error(`Missing Firebase environment variable: ${name}`);
-    throw new Error(`Missing Firebase environment variable: ${name}`);
-  }
-});
+const missing = requiredEnv.filter((name) => !process.env[name]);
+if (missing.length) {
+  console.error(
+    `Missing Firebase environment variables: ${missing.join(', ')}`
+  );
+}
 
-const firebaseConfig = {
-  apiKey: process.env.REACT_APP_FIREBASE_API_KEY,
-  authDomain: process.env.REACT_APP_FIREBASE_AUTH_DOMAIN,
-  databaseURL: process.env.REACT_APP_FIREBASE_DATABASE_URL,
-  projectId: process.env.REACT_APP_FIREBASE_PROJECT_ID,
-  storageBucket: process.env.REACT_APP_FIREBASE_STORAGE_BUCKET,
-  messagingSenderId: process.env.REACT_APP_FIREBASE_MESSAGING_SENDER_ID,
-  appId: process.env.REACT_APP_FIREBASE_APP_ID,
-};
-const app = initializeApp(firebaseConfig);
-export const auth = getAuth(app);
+let app;
+if (!missing.length) {
+  const firebaseConfig = {
+    apiKey: process.env.REACT_APP_FIREBASE_API_KEY,
+    authDomain: process.env.REACT_APP_FIREBASE_AUTH_DOMAIN,
+    databaseURL: process.env.REACT_APP_FIREBASE_DATABASE_URL,
+    projectId: process.env.REACT_APP_FIREBASE_PROJECT_ID,
+    storageBucket: process.env.REACT_APP_FIREBASE_STORAGE_BUCKET,
+    messagingSenderId: process.env.REACT_APP_FIREBASE_MESSAGING_SENDER_ID,
+    appId: process.env.REACT_APP_FIREBASE_APP_ID,
+  };
+  app = initializeApp(firebaseConfig);
+} else {
+  console.warn('Firebase not initialized due to missing configuration.');
+}
+
+export const auth = app ? getAuth(app) : null;


### PR DESCRIPTION
## Summary
- avoid throwing when env vars are missing
- show user-friendly error when Firebase isn't configured
- update test to mock firebase env vars

## Testing
- `npm test -- --watchAll=false`
- `npm start`

------
https://chatgpt.com/codex/tasks/task_e_686c2d450914832994642e429485ae36