### PR TITLE
Add i18n and verification flow

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -10,9 +10,11 @@ import Settings from "./pages/Settings";
 import NavBar from "./components/NavBar";
 import { Box } from "@mui/material";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
+import { useLang } from "./LanguageProvider";
 
 function App() {
   const [user, setUser] = useState(null);
+  const { t } = useLang();
 
   useEffect(() => {
     if (!auth) return;
@@ -22,7 +24,7 @@ function App() {
   if (!auth) {
     return (
       <Box p={2} textAlign="center">
-        Липсва конфигурация за Firebase. Проверете environment променливите.
+        {t('firebaseMissing')}
       </Box>
     );
   }

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
+import { LanguageProvider } from './LanguageProvider';
 
 jest.mock(
   'react-router-dom',
@@ -21,7 +22,13 @@ test('renders home page by default', () => {
   process.env.REACT_APP_FIREBASE_MESSAGING_SENDER_ID = 'test';
   process.env.REACT_APP_FIREBASE_APP_ID = 'test';
 
+  window.localStorage.setItem('lang', 'bg');
+
   const App = require('./App').default;
-  render(<App />);
+  render(
+    <LanguageProvider>
+      <App />
+    </LanguageProvider>
+  );
   expect(screen.getByText(/Добре дошли/i)).toBeInTheDocument();
 });

--- a/src/LanguageProvider.js
+++ b/src/LanguageProvider.js
@@ -1,0 +1,79 @@
+import { createContext, useContext, useEffect, useState } from 'react';
+
+export const translations = {
+  en: {
+    home: 'Home',
+    stats: 'Statistics',
+    settings: 'Settings',
+    login: 'Login',
+    logout: 'Logout',
+    register: 'Register',
+    loginWithGoogle: 'Login with Google',
+    email: 'Email',
+    password: 'Password',
+    verificationSent: 'Confirmation email sent.',
+    awaitingActivation: 'Your account is awaiting activation.',
+    resendLink: 'Resend activation link',
+    welcome: 'Welcome!',
+    mainInfo: 'Main info will be here soon.',
+    statsTitle: 'Statistics',
+    statsInfo: 'Statistical information will be displayed here.',
+    settingsTitle: 'Settings',
+    settingsInfo: 'You will be able to change application settings here.',
+    firebaseMissing:
+      'Firebase configuration missing. Check your environment variables.',
+  },
+  bg: {
+    home: 'Начало',
+    stats: 'Статистики',
+    settings: 'Настройки',
+    login: 'Вход',
+    logout: 'Изход',
+    register: 'Регистрация',
+    loginWithGoogle: 'Вход с Google',
+    email: 'Имейл',
+    password: 'Парола',
+    verificationSent: 'Изпратихме имейл за потвърждение.',
+    awaitingActivation: 'Акаунтът ви очаква активация.',
+    resendLink: 'Изпрати нов линк за активация',
+    welcome: 'Добре дошли!',
+    mainInfo: 'Тук скоро ще има основна информация.',
+    statsTitle: 'Статистики',
+    statsInfo: 'Тук ще визуализираме статистическа информация.',
+    settingsTitle: 'Настройки',
+    settingsInfo: 'Тук ще можете да променяте настройките на приложението.',
+    firebaseMissing:
+      'Липсва конфигурация за Firebase. Проверете environment променливите.',
+  },
+};
+
+const LanguageContext = createContext({
+  lang: 'bg',
+  setLang: () => {},
+  t: (key) => key,
+});
+
+export const useLang = () => useContext(LanguageContext);
+
+export function LanguageProvider({ children }) {
+  const stored = localStorage.getItem('lang');
+  const browserLang =
+    typeof navigator !== 'undefined' && navigator.language
+      ? navigator.language
+      : '';
+  const [lang, setLang] = useState(
+    stored || (browserLang.startsWith('bg') ? 'bg' : 'en')
+  );
+
+  useEffect(() => {
+    localStorage.setItem('lang', lang);
+  }, [lang]);
+
+  const t = (key) => translations[lang][key] || key;
+
+  return (
+    <LanguageContext.Provider value={{ lang, setLang, t }}>
+      {children}
+    </LanguageContext.Provider>
+  );
+}

--- a/src/components/Login.js
+++ b/src/components/Login.js
@@ -9,6 +9,7 @@ import {
 } from "firebase/auth";
 import { auth } from "../firebase";
 import { Button, TextField, Box, Typography, Paper, Alert } from "@mui/material";
+import { useLang } from "../LanguageProvider";
 
 
 function Login() {
@@ -16,6 +17,8 @@ function Login() {
   const [password, setPassword] = useState("");
   const [error, setError] = useState("");
   const [info, setInfo] = useState("");
+  const [unverified, setUnverified] = useState(false);
+  const { t } = useLang();
 
 
 const googleLogin = async () => {
@@ -33,13 +36,12 @@ const googleLogin = async () => {
     try {
       setError("");
       setInfo("");
+      setUnverified(false);
       const cred = await signInWithEmailAndPassword(auth, email, password);
       if (!cred.user.emailVerified) {
-        await sendEmailVerification(cred.user);
-        setError(
-          "Имейлът не е потвърден. Изпратихме нов имейл за потвърждение."
-        );
+        setUnverified(true);
         await signOut(auth);
+        return;
       }
     } catch (err) {
       setError(err.message);
@@ -52,8 +54,19 @@ const googleLogin = async () => {
       setInfo("");
       const cred = await createUserWithEmailAndPassword(auth, email, password);
       await sendEmailVerification(cred.user);
-      setInfo("Изпратихме имейл за потвърждение.");
+      setInfo(t('verificationSent'));
       await signOut(auth);
+    } catch (err) {
+      setError(err.message);
+    }
+  };
+
+  const resendVerification = async () => {
+    try {
+      const cred = await signInWithEmailAndPassword(auth, email, password);
+      await sendEmailVerification(cred.user);
+      await signOut(auth);
+      setInfo(t('verificationSent'));
     } catch (err) {
       setError(err.message);
     }
@@ -64,20 +77,22 @@ const googleLogin = async () => {
 //        <Button variant="contained" fullWidth style={{ marginTop: 16 }}>Вход</Button>
 
 
-return (
+  return (
     <Box display="flex" justifyContent="center" alignItems="center" height="100vh" bgcolor="#f5f5f5">
-      <Paper elevation={3} style={{ padding: 24, width: 320 }}>
-        <Typography variant="h5" align="center" gutterBottom>Вход</Typography>
+      <Paper elevation={3} sx={{ p: 3, width: '100%', maxWidth: 320 }}>
+        <Typography variant="h5" align="center" gutterBottom>
+          {t('login')}
+        </Typography>
         <form onSubmit={login}>
           <TextField
-            label="Имейл"
+            label={t('email')}
             fullWidth
             margin="normal"
             value={email}
             onChange={(e) => setEmail(e.target.value)}
           />
           <TextField
-            label="Парола"
+            label={t('password')}
             type="password"
             fullWidth
             margin="normal"
@@ -94,8 +109,17 @@ return (
               {info}
             </Alert>
           )}
+          {unverified && (
+            <Alert severity="warning" sx={{ mt: 1 }} action={
+              <Button color="inherit" size="small" onClick={resendVerification}>
+                {t('resendLink')}
+              </Button>
+            }>
+              {t('awaitingActivation')}
+            </Alert>
+          )}
           <Button variant="contained" type="submit" fullWidth sx={{ mt: 2 }}>
-            Вход
+            {t('login')}
           </Button>
           <Button
             variant="outlined"
@@ -103,7 +127,7 @@ return (
             sx={{ mt: 2 }}
             onClick={register}
           >
-            Регистрация
+            {t('register')}
           </Button>
         </form>
         <Button
@@ -112,7 +136,7 @@ return (
           sx={{ mt: 2 }}
           onClick={googleLogin}
         >
-          Вход с Google
+          {t('loginWithGoogle')}
         </Button>
       </Paper>
     </Box>

--- a/src/components/LogoutButton.js
+++ b/src/components/LogoutButton.js
@@ -1,15 +1,17 @@
 import { Button } from '@mui/material';
 import { signOut } from 'firebase/auth';
 import { auth } from '../firebase';
+import { useLang } from '../LanguageProvider';
 
 export default function LogoutButton() {
+  const { t } = useLang();
   const handleLogout = () => {
     signOut(auth);
   };
 
   return (
     <Button variant="outlined" color="error" onClick={handleLogout}>
-      Изход
+      {t('logout')}
     </Button>
   );
 }

--- a/src/components/NavBar.js
+++ b/src/components/NavBar.js
@@ -1,26 +1,41 @@
-import { AppBar, Toolbar, Button, Box } from '@mui/material';
+import { AppBar, Toolbar, Button, Box, Select, MenuItem } from '@mui/material';
 import { Link } from 'react-router-dom';
 import LogoutButton from './LogoutButton';
+import { useLang } from '../LanguageProvider';
 
 export default function NavBar({ user }) {
+  const { lang, setLang, t } = useLang();
   return (
     <AppBar position="static">
-      <Toolbar>
-        <Button color="inherit" component={Link} to="/">
-          Начало
-        </Button>
-        <Button color="inherit" component={Link} to="/stats">
-          Статистики
-        </Button>
-        <Button color="inherit" component={Link} to="/settings">
-          Настройки
-        </Button>
+      <Toolbar sx={{ display: 'flex', gap: 2 }}>
+        {user && (
+          <>
+            <Button color="inherit" component={Link} to="/">
+              {t('home')}
+            </Button>
+            <Button color="inherit" component={Link} to="/stats">
+              {t('stats')}
+            </Button>
+            <Button color="inherit" component={Link} to="/settings">
+              {t('settings')}
+            </Button>
+          </>
+        )}
         <Box sx={{ flexGrow: 1 }} />
+        <Select
+          size="small"
+          value={lang}
+          onChange={(e) => setLang(e.target.value)}
+          sx={{ mr: 2, color: 'inherit', borderColor: 'inherit' }}
+        >
+          <MenuItem value="bg">BG</MenuItem>
+          <MenuItem value="en">EN</MenuItem>
+        </Select>
         {user ? (
           <LogoutButton />
         ) : (
           <Button color="inherit" component={Link} to="/login">
-            Вход
+            {t('login')}
           </Button>
         )}
       </Toolbar>

--- a/src/index.js
+++ b/src/index.js
@@ -3,11 +3,14 @@ import ReactDOM from 'react-dom/client';
 import './index.css';
 import App from './App';
 import reportWebVitals from './reportWebVitals';
+import { LanguageProvider } from './LanguageProvider';
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(
   <React.StrictMode>
-    <App />
+    <LanguageProvider>
+      <App />
+    </LanguageProvider>
   </React.StrictMode>
 );
 

--- a/src/pages/Home.js
+++ b/src/pages/Home.js
@@ -1,13 +1,15 @@
 import { Box, Typography } from '@mui/material';
+import { useLang } from '../LanguageProvider';
 
 export default function Home() {
+  const { t } = useLang();
   return (
     <Box p={4} textAlign="center">
       <Typography variant="h4" gutterBottom>
-        Добре дошли!
+        {t('welcome')}
       </Typography>
       <Typography variant="body1" color="text.secondary">
-        Тук скоро ще има основна информация.
+        {t('mainInfo')}
       </Typography>
     </Box>
   );

--- a/src/pages/Settings.js
+++ b/src/pages/Settings.js
@@ -1,13 +1,15 @@
 import { Box, Typography } from '@mui/material';
+import { useLang } from '../LanguageProvider';
 
 export default function Settings() {
+  const { t } = useLang();
   return (
     <Box p={4} textAlign="center">
       <Typography variant="h4" gutterBottom>
-        Настройки
+        {t('settingsTitle')}
       </Typography>
       <Typography variant="body1" color="text.secondary">
-        Тук ще можете да променяте настройките на приложението.
+        {t('settingsInfo')}
       </Typography>
     </Box>
   );

--- a/src/pages/Stats.js
+++ b/src/pages/Stats.js
@@ -1,13 +1,15 @@
 import { Box, Typography } from '@mui/material';
+import { useLang } from '../LanguageProvider';
 
 export default function Stats() {
+  const { t } = useLang();
   return (
     <Box p={4} textAlign="center">
       <Typography variant="h4" gutterBottom>
-        Статистики
+        {t('statsTitle')}
       </Typography>
       <Typography variant="body1" color="text.secondary">
-        Тук ще визуализираме статистическа информация.
+        {t('statsInfo')}
       </Typography>
     </Box>
   );


### PR DESCRIPTION
## Summary
- restrict navigation links to authenticated users
- add language context with BG and EN translations
- show localized labels and allow language selection
- enhance login flow with unverified email handling
- wrap app with language provider
- update tests for i18n

## Testing
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_686cc13baa0c8329b166217b0dc9689c