### PR TITLE
Display signals feed

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -36,7 +36,7 @@ function App() {
         <Route path="/login" element={<Login />} />
         <Route path="/stats" element={<Stats />} />
         <Route path="/settings" element={<Settings />} />
-        <Route path="/" element={<Home />} />
+        <Route path="/" element={<Home user={user} />} />
       </Routes>
     </BrowserRouter>
   );

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -30,5 +30,5 @@ test('renders home page by default', () => {
       <App />
     </LanguageProvider>
   );
-  expect(screen.getByText(/Добре дошли/i)).toBeInTheDocument();
+  expect(screen.getAllByText(/Сигнали/i)[0]).toBeInTheDocument();
 });

--- a/src/LanguageProvider.js
+++ b/src/LanguageProvider.js
@@ -22,6 +22,9 @@ export const translations = {
     settingsInfo: 'You will be able to change application settings here.',
     firebaseMissing:
       'Firebase configuration missing. Check your environment variables.',
+    signalsTitle: 'Signals',
+    signalsLoading: 'Loading signals...',
+    noSignals: 'No signals available.'
   },
   bg: {
     home: 'Начало',
@@ -44,6 +47,9 @@ export const translations = {
     settingsInfo: 'Тук ще можете да променяте настройките на приложението.',
     firebaseMissing:
       'Липсва конфигурация за Firebase. Проверете environment променливите.',
+    signalsTitle: 'Сигнали',
+    signalsLoading: 'Зареждане на сигнали...',
+    noSignals: 'Няма налични сигнали.'
   },
 };
 

--- a/src/components/SignalCard.js
+++ b/src/components/SignalCard.js
@@ -1,0 +1,38 @@
+import { Paper, Typography, Box } from '@mui/material';
+
+export default function SignalCard({ signal }) {
+  if (!signal) return null;
+
+  const startTime = new Date(signal.market?.event?.startTime || signal.market?.event?.competitionInstance?.startAt || '');
+  const foundAt = new Date(signal.lastFoundAt || signal.receivedAt);
+
+  const format = (date) =>
+    isNaN(date) ? '' : date.toLocaleString('en-GB', { timeZone: 'UTC' });
+
+  return (
+    <Paper elevation={3} sx={{ p: 2, display: 'flex', flexDirection: 'column', gap: 0.5 }}>
+      <Typography variant="caption" color="text.secondary">
+        {signal.market?.event?.participants?.[0]?.sport} – {signal.market?.event?.competitionInstance?.competition?.shortName}
+      </Typography>
+      <Typography variant="caption" color="text.secondary">
+        {format(startTime)} UTC
+      </Typography>
+      <Typography variant="subtitle2" sx={{ mt: 1 }}>
+        {signal.market?.event?.participants?.[1]?.name} @ {signal.market?.event?.participants?.[0]?.name}
+      </Typography>
+      <Typography variant="body2">
+        Market: {signal.market?.type} ({signal.market?.segment})
+      </Typography>
+      <Typography variant="body2">Type: {signal.type}</Typography>
+      {signal.outcomes?.map((o) => (
+        <Typography key={o.key} variant="body2">
+          - {o.participant?.name} ({o.modifier > 0 ? '+' : ''}{o.modifier}) → {o.payout} @ {o.source}
+        </Typography>
+      ))}
+      <Box sx={{ flexGrow: 1 }} />
+      <Typography variant="caption" color="text.secondary">
+        Found: {format(foundAt)} UTC
+      </Typography>
+    </Paper>
+  );
+}

--- a/src/firebase.js
+++ b/src/firebase.js
@@ -1,5 +1,6 @@
 import { initializeApp } from 'firebase/app';
 import { getAuth } from 'firebase/auth';
+import { getFirestore } from 'firebase/firestore';
 
 const requiredEnv = [
   'REACT_APP_FIREBASE_API_KEY',
@@ -35,3 +36,4 @@ if (!missing.length) {
 }
 
 export const auth = app ? getAuth(app) : null;
+export const db = app ? getFirestore(app) : null;

--- a/src/pages/Home.js
+++ b/src/pages/Home.js
@@ -1,16 +1,62 @@
 import { Box, Typography } from '@mui/material';
+import { useEffect, useState } from 'react';
 import { useLang } from '../LanguageProvider';
+import { collection, query, orderBy, limit, onSnapshot } from 'firebase/firestore';
+import { db } from '../firebase';
+import SignalCard from '../components/SignalCard';
 
-export default function Home() {
+export default function Home({ user }) {
   const { t } = useLang();
+  const [signals, setSignals] = useState([]);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (!db || !user) return;
+    setLoading(true);
+    const q = query(
+      collection(db, 'signals'),
+      orderBy('receivedAt', 'desc'),
+      limit(20)
+    );
+    const unsub = onSnapshot(
+      q,
+      (snap) => {
+        setSignals(snap.docs.map((d) => ({ id: d.id, ...d.data() })));
+        setLoading(false);
+      },
+      () => setLoading(false)
+    );
+    return unsub;
+  }, []);
+
   return (
-    <Box p={4} textAlign="center">
-      <Typography variant="h4" gutterBottom>
-        {t('welcome')}
+    <Box p={2}>
+      <Typography variant="h5" gutterBottom textAlign="center">
+        {t('signalsTitle')}
       </Typography>
-      <Typography variant="body1" color="text.secondary">
-        {t('mainInfo')}
-      </Typography>
+      {loading && (
+        <Typography align="center" color="text.secondary">
+          {t('signalsLoading')}
+        </Typography>
+      )}
+      {!loading && signals.length === 0 && (
+        <Typography align="center" color="text.secondary">
+          {t('noSignals')}
+        </Typography>
+      )}
+      <Box
+        sx={{
+          display: 'grid',
+          gridTemplateColumns: 'repeat(auto-fit, minmax(260px, 1fr))',
+          gap: 2,
+          mt: 2,
+          gridAutoRows: '1fr',
+        }}
+      >
+        {signals.map((s) => (
+          <SignalCard key={s.id} signal={s} />
+        ))}
+      </Box>
     </Box>
   );
 }


### PR DESCRIPTION
## Summary
- add Firestore initialization
- show signals on the Home page
- create SignalCard component
- adjust translations
- update test for new UI

## Testing
- `npm test --silent --progress=false`

------
https://chatgpt.com/codex/tasks/task_e_686cf8047590832990e184e9aea494d2